### PR TITLE
refactor: remove easyjson dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  workflow_call:
+  push:
+    branches:
+      - "*"
+    tags:
+      - "v*"
+  pull_request:
+    branches:
+      - "*"
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version: 1.20
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: latest
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version: 1.20
+      - run: make test

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,31 +24,6 @@ linters:
     - prealloc
     - misspell
 
-  # disable:
-  #   - maligned
-  #   - lll
-  #   - gochecknoinits
-  #   - gochecknoglobals
-  #   - godox
-  #   - gocognit
-  #   - whitespace
-  #   - wsl
-  #   - funlen
-  #   - wrapcheck
-  #   - testpackage
-  #   - nlreturn
-  #   - gofumpt
-  #   - goerr113
-  #   - gci
-  #   - gomnd
-  #   - godot
-  #   - exhaustivestruct
-  #   - paralleltest
-  #   - varnamelen
-  #   - ireturn
-  #   - exhaustruct
-  #   #- thelper
-
 issues:
   exclude-rules:
     - path: bson.go

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,58 @@
+linters-settings:
+  govet:
+    check-shadowing: true
+  golint:
+    min-confidence: 0
+  gocyclo:
+    min-complexity: 31
+  maligned:
+    suggest-new: true
+  dupl:
+    threshold: 100
+  goconst:
+    min-len: 2
+    min-occurrences: 4
+
+linters:
+  enable:
+    - revive
+    - goimports
+    - gosec
+    - unparam
+    - unconvert
+    - predeclared
+    - prealloc
+    - misspell
+
+  # disable:
+  #   - maligned
+  #   - lll
+  #   - gochecknoinits
+  #   - gochecknoglobals
+  #   - godox
+  #   - gocognit
+  #   - whitespace
+  #   - wsl
+  #   - funlen
+  #   - wrapcheck
+  #   - testpackage
+  #   - nlreturn
+  #   - gofumpt
+  #   - goerr113
+  #   - gci
+  #   - gomnd
+  #   - godot
+  #   - exhaustivestruct
+  #   - paralleltest
+  #   - varnamelen
+  #   - ireturn
+  #   - exhaustruct
+  #   #- thelper
+
+issues:
+  exclude-rules:
+    - path: bson.go
+      text: "should be .*ObjectID"
+      linters:
+        - golint
+        - stylecheck

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+.PHONY: lint
+lint:
+	golangci-lint run
+
+.PHONY: test
+test:
+	go test ./...

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,11 @@
 module github.com/kubewarden/strfmt
 
-go 1.17
+go 1.20
 
-require github.com/mailru/easyjson v0.7.7
+require github.com/stretchr/testify v1.8.4
 
-require github.com/josharian/intern v1.0.0 // indirect
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/types.go
+++ b/types.go
@@ -3,10 +3,8 @@
 package strfmt
 
 import (
+	"encoding/json"
 	"time"
-
-	jlexer "github.com/mailru/easyjson/jlexer"
-	jwriter "github.com/mailru/easyjson/jwriter"
 )
 
 type Base64 []byte
@@ -49,30 +47,17 @@ var (
 
 // MarshalJSON returns the DateTime as JSON
 func (t DateTime) MarshalJSON() ([]byte, error) {
-	w := jwriter.Writer{}
-
-	timeForMarshal := NormalizeTimeForMarshal(time.Time(t))
-
-	if timeForMarshal.IsZero() {
-		w.RawString(jsonNull)
-	} else {
-		tstr, err := timeForMarshal.MarshalJSON()
-		w.Raw(tstr, err)
-	}
-
-	return w.Buffer.BuildBytes(), w.Error
+	return json.Marshal(NormalizeTimeForMarshal(time.Time(t)).Format(MarshalFormat))
 }
 
-// UnmarshalJSON supports json.Unmarshaler interface
+// UnmarshalJSON sets the DateTime from JSON
 func (t *DateTime) UnmarshalJSON(data []byte) error {
-	r := jlexer.Lexer{Data: data}
-
 	if string(data) == jsonNull {
 		return nil
 	}
 
-	var tstr string = string(r.String())
-	if err := r.Error(); err != nil {
+	var tstr string
+	if err := json.Unmarshal(data, &tstr); err != nil {
 		return err
 	}
 	tt, err := ParseDateTime(tstr)

--- a/types_test.go
+++ b/types_test.go
@@ -1,0 +1,104 @@
+// This code has been cherry-picked from https://github.com/go-openapi/strfmt
+
+package strfmt
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	p, _ = time.Parse(time.RFC3339Nano, "2011-08-18T19:03:37.000000000+01:00")
+
+	testCases = []struct {
+		in     []byte    // externally sourced data -- to be unmarshalled
+		time   time.Time // its representation in time.Time
+		str    string    // its marshalled representation
+		utcStr string    // the marshaled representation as utc
+	}{
+		{[]byte("2014-12-15 08:00:00"), time.Date(2014, 12, 15, 8, 0, 0, 0, time.UTC), "2014-12-15T08:00:00.000Z", "2014-12-15T08:00:00.000Z"},
+		{[]byte("2014-12-15T08:00:00"), time.Date(2014, 12, 15, 8, 0, 0, 0, time.UTC), "2014-12-15T08:00:00.000Z", "2014-12-15T08:00:00.000Z"},
+		{[]byte("2014-12-15T08:00"), time.Date(2014, 12, 15, 8, 0, 0, 0, time.UTC), "2014-12-15T08:00:00.000Z", "2014-12-15T08:00:00.000Z"},
+		{[]byte("2014-12-15T08:00Z"), time.Date(2014, 12, 15, 8, 0, 0, 0, time.UTC), "2014-12-15T08:00:00.000Z", "2014-12-15T08:00:00.000Z"},
+		{[]byte("2018-01-28T23:54Z"), time.Date(2018, 01, 28, 23, 54, 0, 0, time.UTC), "2018-01-28T23:54:00.000Z", "2018-01-28T23:54:00.000Z"},
+		{[]byte("2014-12-15T08:00:00.000Z"), time.Date(2014, 12, 15, 8, 0, 0, 0, time.UTC), "2014-12-15T08:00:00.000Z", "2014-12-15T08:00:00.000Z"},
+		{[]byte("2011-08-18T19:03:37.123000000+01:00"), time.Date(2011, 8, 18, 19, 3, 37, 123*1e6, p.Location()), "2011-08-18T19:03:37.123+01:00", "2011-08-18T18:03:37.123Z"},
+		{[]byte("2011-08-18T19:03:37.123000+0100"), time.Date(2011, 8, 18, 19, 3, 37, 123*1e6, p.Location()), "2011-08-18T19:03:37.123+01:00", "2011-08-18T18:03:37.123Z"},
+		{[]byte("2011-08-18T19:03:37.123+0100"), time.Date(2011, 8, 18, 19, 3, 37, 123*1e6, p.Location()), "2011-08-18T19:03:37.123+01:00", "2011-08-18T18:03:37.123Z"},
+		{[]byte("2014-12-15T19:30:20Z"), time.Date(2014, 12, 15, 19, 30, 20, 0, time.UTC), "2014-12-15T19:30:20.000Z", "2014-12-15T19:30:20.000Z"},
+		{[]byte("0001-01-01T00:00:00Z"), time.Time{}.UTC(), "0001-01-01T00:00:00.000Z", "0001-01-01T00:00:00.000Z"},
+		{[]byte(""), time.Unix(0, 0).UTC(), "1970-01-01T00:00:00.000Z", "1970-01-01T00:00:00.000Z"},
+		{[]byte(nil), time.Unix(0, 0).UTC(), "1970-01-01T00:00:00.000Z", "1970-01-01T00:00:00.000Z"},
+	}
+)
+
+func TestNewDateTime(t *testing.T) {
+	assert.EqualValues(t, time.Unix(0, 0).UTC(), NewDateTime())
+}
+
+func TestParseDateTime_errorCases(t *testing.T) {
+	_, err := ParseDateTime("yada")
+	assert.Error(t, err)
+}
+
+func TestDateTime_UnmarshalJSON(t *testing.T) {
+	for caseNum, example := range testCases {
+		t.Logf("Case #%d", caseNum)
+		pp := NewDateTime()
+		err := pp.UnmarshalJSON(esc(example.in))
+		assert.NoError(t, err)
+		assert.EqualValues(t, example.time, pp)
+	}
+
+	// Check UnmarshalJSON failure with no lexed items
+	pp := NewDateTime()
+	err := pp.UnmarshalJSON([]byte("zorg emperor"))
+	assert.Error(t, err)
+
+	// Check lexer failure
+	err = pp.UnmarshalJSON([]byte(`"zorg emperor"`))
+	assert.Error(t, err)
+
+	// Check null case
+	err = pp.UnmarshalJSON([]byte("null"))
+	assert.Nil(t, err)
+}
+
+func TestDateTime_MarshalJSON(t *testing.T) {
+	for caseNum, example := range testCases {
+		t.Logf("Case #%d", caseNum)
+		dt := DateTime(example.time)
+		bb, err := dt.MarshalJSON()
+		assert.NoError(t, err)
+		assert.EqualValues(t, esc([]byte(example.str)), bb)
+	}
+}
+
+func TestDateTime_MarshalJSON_Override(t *testing.T) {
+	oldNormalizeMarshal := NormalizeTimeForMarshal
+	defer func() {
+		NormalizeTimeForMarshal = oldNormalizeMarshal
+	}()
+
+	NormalizeTimeForMarshal = func(t time.Time) time.Time {
+		return t.UTC()
+	}
+	for caseNum, example := range testCases {
+		t.Logf("Case #%d", caseNum)
+		dt := DateTime(example.time.UTC())
+		bb, err := dt.MarshalJSON()
+		assert.NoError(t, err)
+		assert.EqualValues(t, esc([]byte(example.utcStr)), bb)
+	}
+}
+
+func esc(v []byte) []byte {
+	var buf bytes.Buffer
+	buf.WriteByte('"')
+	buf.Write(v)
+	buf.WriteByte('"')
+	return buf.Bytes()
+}


### PR DESCRIPTION
## Description

Removes the easyjson dependency,  as the recent version of tinygo (0.28.1) now provides sufficient reflection capabilities to allow `encoding/json` to work properly.
The `MarshalJSON` and `UnmarshalJSON` were cherry-picked from upstream back to this repo.

## Test

Tests were cherry-picked from the [upstream strfmt repository](https://github.com/go-openapi/strfmt/blob/master/time_test.go) and a basic CI was added.

Please note that in the previous implementation, tests related to MarshalJSON were failing.

## Additional Information

-  I attempted to compile the original library without success, as it relies on some functions of the net package, which are not yet implemented in tinygo.

- Currently, the tests are not running with tinygo due to the presence of the testify dependency.
