### PR TITLE
fix(ci): fix setup-go version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: 1.20
+          go-version: "1.20"
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
@@ -30,5 +30,5 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: 1.20
+          go-version: "1.20"
       - run: make test


### PR DESCRIPTION
## Description

Fixes the go version `1.20` being interpreted as `1.2` by the GitHub action runner.

## Test

Tested in fork. 

## Additional Information
-


